### PR TITLE
array methods

### DIFF
--- a/conder_core/src/main/abstract/IR.ts
+++ b/conder_core/src/main/abstract/IR.ts
@@ -1,7 +1,7 @@
 import { AnyOpInstance, Utils } from '../ops/index';
 
 export type Node<DATA={}, META extends "root" | "not root"="not root"> = DATA & {_meta: META}
-type ValueNode = PickNode<
+export type ValueNode = PickNode<
     "Bool" | 
     "Object" | 
     "Comparison" | 
@@ -17,16 +17,16 @@ type ValueNode = PickNode<
     "ArrayLiteral"
     >
 
-
+export type Key = PickNode<"String" | "Saved">
 export type AbstractNodes = PickNode<"GlobalObject">
 
 export type BaseNodeDefs = {
     Return: Node<{value?: ValueNode}, "root">
     Bool: Node<{value: boolean}>
-    SetField: Node<{field_name: PickNode<"String" | "Saved">[], value: ValueNode}>
-    GetField: Node<{field_name: PickNode<"String" | "Saved">[], target: PickNode<"Saved" | "GlobalObject">}>,
-    DeleteField: Node<{field_name: PickNode<"String" | "Saved">[]}>,
-    Object: Node<{fields: PickNode<"SetField">[]}>
+    GetField: Node<{field_name: Key[], target: PickNode<"Saved" | "GlobalObject">}>,
+    DeleteField: Node<{}>,
+    Field: Node<{key: Key, value: ValueNode}>
+    Object: Node<{fields: PickNode<"Field">[]}>
     Int: Node<{value: number}> 
     None: Node<{}>
     Comparison: Node<
@@ -55,11 +55,12 @@ export type BaseNodeDefs = {
     Noop: Node<{}, "root">
     Saved: Node<{index: number}> 
     String: Node<{value: string}>
-    FieldExists: Node<{value: ValueNode, field: PickNode<"String">}>
+    FieldExists: Node<{value: ValueNode, field: Key}>
     Save: Node<{value: ValueNode}, "root">
     Update: Node<{
-        target: PickNode<"Saved" | "GlobalObject">, 
-        operation: PickNode<"SetField" | "DeleteField" | "Push"> | ValueNode,
+        target: PickNode<"Saved" | "GlobalObject">,
+        level: Key[]
+        operation: PickNode<"DeleteField" | "Push"> | ValueNode,
     }, "root">
     GlobalObject: Node<{name: string}>
     ArrayForEach: Node<{target: ValueNode, do: RootNode[]}, "root">
@@ -145,7 +146,7 @@ const PASS_THROUGH_REPLACER: PassThroughReplacer = {
     String: n => n,
     DeleteField: n => n,
     None: _ => _,
-    Noop: _ => _
+    Noop: _ => _,
 }
 
 export function make_replacer<R extends NodeSet>(repl: RequiredReplacer<R>): GenericReplacer<R> {

--- a/conder_core/src/main/abstract/IR.ts
+++ b/conder_core/src/main/abstract/IR.ts
@@ -59,11 +59,12 @@ export type BaseNodeDefs = {
     Save: Node<{value: ValueNode}, "root">
     Update: Node<{
         target: PickNode<"Saved" | "GlobalObject">, 
-        operation: PickNode<"SetField" | "DeleteField"> | ValueNode,
+        operation: PickNode<"SetField" | "DeleteField" | "Push"> | ValueNode,
     }, "root">
     GlobalObject: Node<{name: string}>
     ArrayForEach: Node<{target: ValueNode, do: RootNode[]}, "root">
     ArrayLiteral: Node<{values: ValueNode[]}>
+    Push: Node<{values: ValueNode[]}>
 }
 
 export type NodeSet= {[K in string]: Node<{}, "not root" | "root">} 

--- a/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
+++ b/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
@@ -44,6 +44,12 @@ Map {
 }
 `;
 
+exports[`basic functionality allows pushing to nested local arrays: Required locks 1`] = `
+Map {
+  "push" => Map {},
+}
+`;
+
 exports[`basic functionality can compare numbers: Required locks 1`] = `
 Map {
   "geq" => Map {},

--- a/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
+++ b/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
@@ -119,6 +119,13 @@ Map {
 }
 `;
 
+exports[`global objects allows getting a key with a number key: Required locks 1`] = `
+Map {
+  "get" => Map {},
+  "set" => Map {},
+}
+`;
+
 exports[`global objects can check existence of keys: Required locks 1`] = `
 Map {
   "set" => Map {},

--- a/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
+++ b/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
@@ -32,6 +32,12 @@ Map {
 }
 `;
 
+exports[`basic functionality allows pushing to local arrays: Required locks 1`] = `
+Map {
+  "push" => Map {},
+}
+`;
+
 exports[`basic functionality can compare numbers: Required locks 1`] = `
 Map {
   "geq" => Map {},

--- a/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
+++ b/conder_core/src/main/abstract/__snapshots__/abstract.spec.ts.snap
@@ -32,6 +32,12 @@ Map {
 }
 `;
 
+exports[`basic functionality allows indexing into arrays with an int: Required locks 1`] = `
+Map {
+  "getFirst" => Map {},
+}
+`;
+
 exports[`basic functionality allows pushing to local arrays: Required locks 1`] = `
 Map {
   "push" => Map {},

--- a/conder_core/src/main/abstract/abstract.spec.ts
+++ b/conder_core/src/main/abstract/abstract.spec.ts
@@ -561,6 +561,39 @@ describe("global objects", () => {
         )
     )
 
+    it("allows getting a key with a number key", noInputHarness({
+        get: [
+            {
+                kind: "Return", 
+                value: {
+                    kind: "Selection", 
+                    root: {
+                        kind: "GlobalObject", 
+                        name: TEST_STORE
+                    },
+                    level: [{
+                        kind: "Int",
+                        value: 1
+                    }]
+                }
+            }
+        ],
+        set: [
+            {
+                kind: "Update",
+                root: {kind: "GlobalObject", name: TEST_STORE},
+                level: [{kind: "Int", value: 1}],
+                operation: {kind: "String", value: "Number field"}
+            }
+        ]
+    },
+    async server => {
+        expect(await server.set()).toBeNull()
+        expect(await server.get()).toEqual("Number field")
+    },
+    "requires storage"
+    ))
+
     const getNested: RootNode[] = [
         {
             kind: "Return", 

--- a/conder_core/src/main/abstract/abstract.spec.ts
+++ b/conder_core/src/main/abstract/abstract.spec.ts
@@ -119,8 +119,8 @@ describe("basic functionality", () => {
                 value: {
                     kind: "Object", 
                     fields: [{
-                        kind: "SetField", 
-                        field_name: [{kind: "String", value: "some_field"}], 
+                        kind: "Field", 
+                        key: {kind: "String", value: "some_field"}, 
                         value: {
                             kind: "Bool", 
                             value: false
@@ -140,8 +140,8 @@ describe("basic functionality", () => {
                     value: {
                         kind: "Object", 
                         fields: [{
-                            kind: "SetField", 
-                            field_name: [{kind: "String", value: "nested"}], 
+                            kind: "Field",
+                            key: {kind: "String", value: "nested"}, 
                             value: {
                                 kind: "Object", 
                                 fields: []
@@ -152,11 +152,8 @@ describe("basic functionality", () => {
                 {
                     kind: "Update",
                     target: {kind: "Saved", index: 0},
-                    operation: {
-                        kind: "SetField",
-                        field_name: [{kind: "String", value: "nested"}, {kind: "String", value: "inside"}],
-                        value: { kind: "String", value: "hello world"}
-                    }
+                    level: [{kind: "String", value: "nested"}, {kind: "String", value: "inside"}],
+                    operation: { kind: "String", value: "hello world"}
                 },
                 {kind: "Return", value: {kind: "Saved", index: 0}}
             ]
@@ -175,7 +172,8 @@ describe("basic functionality", () => {
                         {
                             kind: "Update", 
                             target: {kind: "Saved", index: 0},
-                            operation: {kind: "DeleteField", field_name: [{kind: "String", value: "some_key"}]}
+                            level: [{kind: "String", value: "some_key"}],
+                            operation: {kind: "DeleteField"}
                         },
                         {
                             kind: "Return",
@@ -198,9 +196,8 @@ describe("basic functionality", () => {
                         {
                             kind: "Update", 
                             target: {kind: "Saved", index: 0},
-                            operation: {
-                                kind: "DeleteField", 
-                                field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]}
+                            level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
+                            operation: {kind: "DeleteField"}
                         },
                         {
                             kind: "Return",
@@ -221,8 +218,8 @@ describe("basic functionality", () => {
                     value: {
                         kind: "Object", 
                         fields: [{
-                            kind: "SetField", 
-                            field_name: [{kind: "String", value: "l1"}], 
+                            kind: "Field", 
+                            key: {kind: "String", value: "l1"}, 
                             value: {
                                 kind: "Object", 
                                 fields: []
@@ -233,11 +230,8 @@ describe("basic functionality", () => {
                 {
                     kind: "Update",
                     target: {kind: "Saved", index: 0},
-                    operation: {
-                        kind: "SetField",
-                        field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                        value: { kind: "String", value: "hello world"}
-                    }
+                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
+                    operation: { kind: "String", value: "hello world"}
                 },
                 {kind: "Return", value: {
                     kind: "GetField", 
@@ -447,6 +441,7 @@ describe("basic functionality", () => {
                     {
                         kind: "Update",
                         target: {kind: "Saved", index: 0},
+                        level: [],
                         operation: {
                             kind: "Push", 
                             values: [
@@ -540,19 +535,16 @@ describe("global objects", () => {
     const set: RootNode[] = [{
         kind: "Update",
         target: {kind: "GlobalObject", name: TEST_STORE},
-        operation: {
-            kind: "SetField",
-            field_name: [{kind: "String", value: "l1"}],
-            value: {kind: "Object", fields: [
-                {
-                    kind: "SetField", 
-                    value: {
-                        kind: "Int", value: 42
-                    },
-                    field_name: [{kind: "String", value: "l2"}]
-                }
-            ]}
-        }
+        level: [{kind: "String", value: "l1"}],
+        operation: {kind: "Object", fields: [
+            {
+                kind: "Field",
+                value: {
+                    kind: "Int", value: 42
+                },
+                key: {kind: "String", value: "l2"}
+            }
+        ]}
     }]
 
     it("getting a key returns the value",
@@ -595,13 +587,10 @@ describe("global objects", () => {
     const setNested: RootNode[] = [{
         kind: "Update",
         target: {kind: "GlobalObject", name: TEST_STORE},
+        level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
         operation: {
-            kind: "SetField",
-            field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-            value: {
-                kind: "Int", value: 41
-            }             
-        }
+            kind: "Int", value: 41
+        }      
     }]
     it("setting a nested key on a non existent object throws an error",
         noInputHarness(
@@ -671,7 +660,8 @@ describe("global objects", () => {
                         {
                             kind: "Update", 
                             target: {kind: "GlobalObject", name: TEST_STORE},
-                            operation: {kind: "DeleteField", field_name: [{kind: "String", value: "l1"}]}
+                            level: [{kind: "String", value: "l1"}],
+                            operation: {kind: "DeleteField"}
                         }
                     ],
                 set,
@@ -695,9 +685,8 @@ describe("global objects", () => {
                         {
                             kind: "Update", 
                             target: {kind: "GlobalObject", name: TEST_STORE},
-                            operation: {
-                                kind: "DeleteField", 
-                                field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]}
+                            level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
+                            operation: {kind: "DeleteField"}
                         }
                     ],
                 set,
@@ -739,6 +728,7 @@ describe("global objects", () => {
                                             left: {kind: "Saved", index: 1},
                                             right: {kind: "Saved", index: 2}
                                         },
+                                        level: [],
                                         target: {kind: "Saved", index: 1}
                                     }
                                 ]
@@ -764,19 +754,16 @@ describe("global objects", () => {
                 setToSelfPlusOne: [{
                     kind: "Update",
                     target: {kind: "GlobalObject", name: TEST_STORE},
+                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
-                        kind: "SetField",
-                        field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                        value: {
-                            kind: "Math",
-                            left: {
-                                kind: "GetField", 
-                                target: {kind: "GlobalObject", name: TEST_STORE},
-                                field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
-                            },
-                            right: {kind: "Int", value: 1},
-                            sign: "+"
-                        }
+                        kind: "Math",
+                        left: {
+                            kind: "GetField", 
+                            target: {kind: "GlobalObject", name: TEST_STORE},
+                            field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
+                        },
+                        right: {kind: "Int", value: 1},
+                        sign: "+"
                     }
                 }]
             },
@@ -801,11 +788,8 @@ describe("global objects", () => {
                                 do: [{
                                     kind: "Update",
                                     target: {kind: "GlobalObject", name: TEST_STORE},
-                                    operation: {
-                                        kind: "SetField",
-                                        field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                                        value: {kind: "Int", value: 0}
-                                    }
+                                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
+                                    operation: {kind: "Int", value: 0}
                                 }]
                             }
                         ]
@@ -841,11 +825,8 @@ describe("global objects", () => {
                                 do: [{
                                     kind: "Update",
                                     target: {kind: "GlobalObject", name: TEST_STORE},
-                                    operation: {
-                                        kind: "SetField",
-                                        field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                                        value: {kind: "Int", value: 0}
-                                    }
+                                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
+                                    operation: {kind: "Int", value: 0}
                                 }]
                             }
                         ]
@@ -865,28 +846,22 @@ describe("global objects", () => {
                 setOther: [{
                     kind: "Update", 
                     target: {kind: "GlobalObject", name: "other"}, 
-                    operation: {
-                        kind: "SetField", 
-                        field_name: [{kind: "String", value: "l1"}],
-                        value: {kind: "Int", value: 734}
-                    }
+                    level: [{kind: "String", value: "l1"}],
+                    operation: {kind: "Int", value: 734}
                 }],
                 setToOtherPlusOne: [{
                     kind: "Update",
                     target: {kind: "GlobalObject", name: TEST_STORE},
+                    level: [{kind: "String", value: "l1"}],
                     operation: {
-                        kind: "SetField",
-                        field_name: [{kind: "String", value: "l1"}],
-                        value: {
-                            kind: "Math",
-                            left: {
-                                kind: "GetField", 
-                                target: {kind: "GlobalObject", name: "other"},
-                                field_name: [{kind: "String", value: "l1"}]
-                            },
-                            right: {kind: "Int", value: 1},
-                            sign: "+"
-                        }
+                        kind: "Math",
+                        left: {
+                            kind: "GetField", 
+                            target: {kind: "GlobalObject", name: "other"},
+                            field_name: [{kind: "String", value: "l1"}]
+                        },
+                        right: {kind: "Int", value: 1},
+                        sign: "+"
                     }
                 }]
             },
@@ -914,15 +889,12 @@ describe("global objects", () => {
                     {
                     kind: "Update",
                     target: {kind: "GlobalObject", name: TEST_STORE},
+                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
-                        kind: "SetField",
-                        field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                        value: {
-                            kind: "Math",
-                            left: {kind: "Saved", index: 0},
-                            right: {kind: "Int", value: 1},
-                            sign: "+"
-                        }
+                        kind: "Math",
+                        left: {kind: "Saved", index: 0},
+                        right: {kind: "Int", value: 1},
+                        sign: "+"
                     }
                 }]
             },
@@ -953,15 +925,12 @@ describe("global objects", () => {
                     {
                     kind: "Update",
                     target: {kind: "GlobalObject", name: TEST_STORE},
+                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
-                        kind: "SetField",
-                        field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                        value: {
-                            kind: "Math",
-                            left: {kind: "Saved", index: 1},
-                            right: {kind: "Int", value: 1},
-                            sign: "+"
-                        }
+                        kind: "Math",
+                        left: {kind: "Saved", index: 1},
+                        right: {kind: "Int", value: 1},
+                        sign: "+"
                     }
                 }]
             },
@@ -984,6 +953,7 @@ describe("global objects", () => {
                     {
                         kind: "Update", 
                         target: {kind: "Saved", index: 0},
+                        level: [],
                         operation: {
                             kind: "GetField", 
                             target: {kind: "GlobalObject", name: TEST_STORE},
@@ -993,15 +963,12 @@ describe("global objects", () => {
                     {
                     kind: "Update",
                     target: {kind: "GlobalObject", name: TEST_STORE},
+                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
-                        kind: "SetField",
-                        field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                        value: {
-                            kind: "Math",
-                            left: {kind: "Saved", index: 0},
-                            right: {kind: "Int", value: 1},
-                            sign: "+"
-                        }
+                        kind: "Math",
+                        left: {kind: "Saved", index: 0},
+                        right: {kind: "Int", value: 1},
+                        sign: "+"
                     }
                 }]
             },
@@ -1018,11 +985,8 @@ describe("global objects", () => {
             setLookupKeys: [
                 {
                     kind: "Update",
-                    operation: {
-                        kind: "SetField", 
-                        field_name: [{kind: "String", value: "arr"}],
-                        value: {kind: "ArrayLiteral", values: [{kind: "String", value: "l1"}]}
-                    },
+                    level: [{kind: "String", value: "arr"}],
+                    operation: {kind: "ArrayLiteral", values: [{kind: "String", value: "l1"}]},
                     target: {kind: "GlobalObject", name: TEST_STORE}
                 }
             ],
@@ -1038,7 +1002,8 @@ describe("global objects", () => {
                         {
                             kind: "Update", 
                             target: {kind: "GlobalObject", name: TEST_STORE},
-                            operation: {kind: "DeleteField", field_name: [{kind: "String", value: "l1"}]}
+                            level: [{kind: "String", value: "l1"}],
+                            operation: {kind: "DeleteField"}
                         }
                     ]
                 }
@@ -1061,29 +1026,28 @@ describe("global objects", () => {
                     {
                         kind: "Save",
                         value: {kind: "Object", fields: [{
-                            kind: "SetField",
+                            kind: "Field",
                             value: {
                                 kind: "GetField", 
                                 target: {kind: "GlobalObject", name: TEST_STORE},
                                 field_name: [{kind: "String", value: "l1"}]
                             },
-                            field_name: [{kind: "String", value: "global_origin"}]
+                            key: {kind: "String", value: "global_origin"}
                         }]}
                     },
                     {
                         kind: "Update", 
                         target: {kind: "Saved", index: 0},
-                        operation: {kind: "SetField", field_name: [{kind: "String",value: "clean"}], value: {kind: "Int", value: 12}},
+                        level: [{kind: "String",value: "clean"}],
+                        operation: {kind: "Int", value: 12},
                     },
                     {
                         kind: "Update",
                         target: {kind: "GlobalObject", name: TEST_STORE},
-                        operation: {
-                            kind: "SetField",
-                            field_name: [{kind: "String", value: "l1"}],
-                            value: {kind: "Saved", index: 0}
+                        level: [{kind: "String", value: "l1"}],
+                        operation: {kind: "Saved", index: 0}
                     }
-                }]
+                ]
             },
             async server => {
                 expect(await server.set()).toBeNull()
@@ -1100,28 +1064,26 @@ describe("global objects", () => {
                     {
                         kind: "Save",
                         value: {kind: "Object", fields: [{
-                            kind: "SetField",
+                            kind: "Field",
                             value: {
                                 kind: "GetField", 
                                 target: {kind: "GlobalObject", name: TEST_STORE},
                                 field_name: [{kind: "String", value: "l1"}]
                             },
-                            field_name: [{kind: "String", value: "global_origin"}]
+                            key: {kind: "String", value: "global_origin"}
                         }]}
                     },
                     {
                         kind: "Update", 
                         target: {kind: "Saved", index: 0},
+                        level: [],
                         operation: {kind: "Int", value: 0},
                     },
                     {
                         kind: "Update",
                         target: {kind: "GlobalObject", name: TEST_STORE},
-                        operation: {
-                            kind: "SetField",
-                            field_name: [{kind: "String", value: "l1"}],
-                            value: {kind: "Saved", index: 0}
-                    }
+                        level: [{kind: "String", value: "l1"}],
+                        operation: {kind: "Saved", index: 0}
                 }]
             },
             async server => {

--- a/conder_core/src/main/abstract/abstract.spec.ts
+++ b/conder_core/src/main/abstract/abstract.spec.ts
@@ -458,6 +458,28 @@ describe("basic functionality", () => {
             expect(await server.push(["a"])).toEqual(["a", "hello", 12])
         }
     ))
+
+    it("allows indexing into arrays with an int", withInputHarness(
+        "requires storage",
+        {
+            getFirst: {
+                input: [schemaFactory.Array(schemaFactory.Any)],
+                computation: [
+                    {
+                        kind: "Return",
+                        value: {
+                            kind: "Selection",
+                            root: {kind: "Saved", index:0},
+                            level: [{kind: "Int", value: 0}]
+                        }
+                    }
+                ]
+            }
+        },
+        async server => {
+            expect(await server.getFirst(["a", "b"])).toBe("a")
+        }
+    ))
 })
 
 describe("with input", () => {

--- a/conder_core/src/main/abstract/abstract.spec.ts
+++ b/conder_core/src/main/abstract/abstract.spec.ts
@@ -151,7 +151,7 @@ describe("basic functionality", () => {
                 },
                 {
                     kind: "Update",
-                    target: {kind: "Saved", index: 0},
+                    root: {kind: "Saved", index: 0},
                     level: [{kind: "String", value: "nested"}, {kind: "String", value: "inside"}],
                     operation: { kind: "String", value: "hello world"}
                 },
@@ -171,7 +171,7 @@ describe("basic functionality", () => {
                     computation: [
                         {
                             kind: "Update", 
-                            target: {kind: "Saved", index: 0},
+                            root:{kind: "Saved", index: 0},
                             level: [{kind: "String", value: "some_key"}],
                             operation: {kind: "DeleteField"}
                         },
@@ -195,7 +195,7 @@ describe("basic functionality", () => {
                     computation: [
                         {
                             kind: "Update", 
-                            target: {kind: "Saved", index: 0},
+                            root: {kind: "Saved", index: 0},
                             level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                             operation: {kind: "DeleteField"}
                         },
@@ -229,14 +229,14 @@ describe("basic functionality", () => {
                 },
                 {
                     kind: "Update",
-                    target: {kind: "Saved", index: 0},
+                    root: {kind: "Saved", index: 0},
                     level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: { kind: "String", value: "hello world"}
                 },
                 {kind: "Return", value: {
-                    kind: "GetField", 
-                    field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
-                    target: {kind: "Saved", index: 0}
+                    kind: "Selection", 
+                    level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
+                    root: {kind: "Saved", index: 0}
                 }}
             ]
         }, async (server) => {
@@ -440,7 +440,7 @@ describe("basic functionality", () => {
                 computation: [
                     {
                         kind: "Update",
-                        target: {kind: "Saved", index: 0},
+                        root: {kind: "Saved", index: 0},
                         level: [],
                         operation: {
                             kind: "Push", 
@@ -510,12 +510,12 @@ describe("global objects", () => {
         {
             kind: "Return", 
             value: {
-                kind: "GetField", 
-                target: {
+                kind: "Selection", 
+                root: {
                     kind: "GlobalObject", 
                     name: TEST_STORE
                 },
-                field_name: [{
+                level: [{
                     kind: "String",
                     value: "l1"
                 }]
@@ -534,7 +534,7 @@ describe("global objects", () => {
 
     const set: RootNode[] = [{
         kind: "Update",
-        target: {kind: "GlobalObject", name: TEST_STORE},
+        root: {kind: "GlobalObject", name: TEST_STORE},
         level: [{kind: "String", value: "l1"}],
         operation: {kind: "Object", fields: [
             {
@@ -565,12 +565,12 @@ describe("global objects", () => {
         {
             kind: "Return", 
             value: {
-                kind: "GetField", 
-                target: {
+                kind: "Selection", 
+                root: {
                     kind: "GlobalObject", 
                     name: TEST_STORE
                 },
-                field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
+                level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
             }
         }
     ]
@@ -586,7 +586,7 @@ describe("global objects", () => {
 
     const setNested: RootNode[] = [{
         kind: "Update",
-        target: {kind: "GlobalObject", name: TEST_STORE},
+        root: {kind: "GlobalObject", name: TEST_STORE},
         level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
         operation: {
             kind: "Int", value: 41
@@ -659,7 +659,7 @@ describe("global objects", () => {
                 delete: [
                         {
                             kind: "Update", 
-                            target: {kind: "GlobalObject", name: TEST_STORE},
+                            root: {kind: "GlobalObject", name: TEST_STORE},
                             level: [{kind: "String", value: "l1"}],
                             operation: {kind: "DeleteField"}
                         }
@@ -684,7 +684,7 @@ describe("global objects", () => {
                 delete: [
                         {
                             kind: "Update", 
-                            target: {kind: "GlobalObject", name: TEST_STORE},
+                            root: {kind: "GlobalObject", name: TEST_STORE},
                             level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                             operation: {kind: "DeleteField"}
                         }
@@ -729,7 +729,7 @@ describe("global objects", () => {
                                             right: {kind: "Saved", index: 2}
                                         },
                                         level: [],
-                                        target: {kind: "Saved", index: 1}
+                                        root: {kind: "Saved", index: 1}
                                     }
                                 ]
                             },
@@ -753,14 +753,14 @@ describe("global objects", () => {
                 set,
                 setToSelfPlusOne: [{
                     kind: "Update",
-                    target: {kind: "GlobalObject", name: TEST_STORE},
+                    root: {kind: "GlobalObject", name: TEST_STORE},
                     level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
                         kind: "Math",
                         left: {
-                            kind: "GetField", 
-                            target: {kind: "GlobalObject", name: TEST_STORE},
-                            field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
+                            kind: "Selection", 
+                            root: {kind: "GlobalObject", name: TEST_STORE},
+                            level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
                         },
                         right: {kind: "Int", value: 1},
                         sign: "+"
@@ -787,7 +787,7 @@ describe("global objects", () => {
                                 cond: {kind: "FieldExists", field: {kind: "String", value: "l1"}, value: {kind: "GlobalObject", name: TEST_STORE}},
                                 do: [{
                                     kind: "Update",
-                                    target: {kind: "GlobalObject", name: TEST_STORE},
+                                    root: {kind: "GlobalObject", name: TEST_STORE},
                                     level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                                     operation: {kind: "Int", value: 0}
                                 }]
@@ -824,7 +824,7 @@ describe("global objects", () => {
                                 kind: "Finally",
                                 do: [{
                                     kind: "Update",
-                                    target: {kind: "GlobalObject", name: TEST_STORE},
+                                    root: {kind: "GlobalObject", name: TEST_STORE},
                                     level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                                     operation: {kind: "Int", value: 0}
                                 }]
@@ -845,20 +845,20 @@ describe("global objects", () => {
                 get, 
                 setOther: [{
                     kind: "Update", 
-                    target: {kind: "GlobalObject", name: "other"}, 
+                    root: {kind: "GlobalObject", name: "other"}, 
                     level: [{kind: "String", value: "l1"}],
                     operation: {kind: "Int", value: 734}
                 }],
                 setToOtherPlusOne: [{
                     kind: "Update",
-                    target: {kind: "GlobalObject", name: TEST_STORE},
+                    root: {kind: "GlobalObject", name: TEST_STORE},
                     level: [{kind: "String", value: "l1"}],
                     operation: {
                         kind: "Math",
                         left: {
-                            kind: "GetField", 
-                            target: {kind: "GlobalObject", name: "other"},
-                            field_name: [{kind: "String", value: "l1"}]
+                            kind: "Selection", 
+                            root: {kind: "GlobalObject", name: "other"},
+                            level: [{kind: "String", value: "l1"}]
                         },
                         right: {kind: "Int", value: 1},
                         sign: "+"
@@ -881,14 +881,14 @@ describe("global objects", () => {
                     {
                         kind: "Save",
                         value: {
-                            kind: "GetField", 
-                            target: {kind: "GlobalObject", name: TEST_STORE},
-                            field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
+                            kind: "Selection", 
+                            root: {kind: "GlobalObject", name: TEST_STORE},
+                            level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
                         }
                     },
                     {
                     kind: "Update",
-                    target: {kind: "GlobalObject", name: TEST_STORE},
+                    root: {kind: "GlobalObject", name: TEST_STORE},
                     level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
                         kind: "Math",
@@ -913,9 +913,9 @@ describe("global objects", () => {
                     {
                         kind: "Save",
                         value: {
-                            kind: "GetField", 
-                            target: {kind: "GlobalObject", name: TEST_STORE},
-                            field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
+                            kind: "Selection", 
+                            root: {kind: "GlobalObject", name: TEST_STORE},
+                            level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
                         }
                     },
                     {
@@ -924,7 +924,7 @@ describe("global objects", () => {
                     },
                     {
                     kind: "Update",
-                    target: {kind: "GlobalObject", name: TEST_STORE},
+                    root: {kind: "GlobalObject", name: TEST_STORE},
                     level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
                         kind: "Math",
@@ -952,17 +952,17 @@ describe("global objects", () => {
                     },
                     {
                         kind: "Update", 
-                        target: {kind: "Saved", index: 0},
+                        root: {kind: "Saved", index: 0},
                         level: [],
                         operation: {
-                            kind: "GetField", 
-                            target: {kind: "GlobalObject", name: TEST_STORE},
-                            field_name: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
+                            kind: "Selection", 
+                            root: {kind: "GlobalObject", name: TEST_STORE},
+                            level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}]
                         },
                     },
                     {
                     kind: "Update",
-                    target: {kind: "GlobalObject", name: TEST_STORE},
+                    root: {kind: "GlobalObject", name: TEST_STORE},
                     level: [{kind: "String", value: "l1"}, {kind: "String", value: "l2"}],
                     operation: {
                         kind: "Math",
@@ -987,21 +987,21 @@ describe("global objects", () => {
                     kind: "Update",
                     level: [{kind: "String", value: "arr"}],
                     operation: {kind: "ArrayLiteral", values: [{kind: "String", value: "l1"}]},
-                    target: {kind: "GlobalObject", name: TEST_STORE}
+                    root: {kind: "GlobalObject", name: TEST_STORE}
                 }
             ],
             deleteLookupFields: [
                 {
                     kind: "ArrayForEach",
                     target: {
-                        kind: "GetField", 
-                        target: {kind: "GlobalObject", name: TEST_STORE},
-                        field_name: [{kind: "String", value: "arr"}]
+                        kind: "Selection", 
+                        root: {kind: "GlobalObject", name: TEST_STORE},
+                        level: [{kind: "String", value: "arr"}]
                     },
                     do: [
                         {
                             kind: "Update", 
-                            target: {kind: "GlobalObject", name: TEST_STORE},
+                            root: {kind: "GlobalObject", name: TEST_STORE},
                             level: [{kind: "String", value: "l1"}],
                             operation: {kind: "DeleteField"}
                         }
@@ -1028,22 +1028,22 @@ describe("global objects", () => {
                         value: {kind: "Object", fields: [{
                             kind: "Field",
                             value: {
-                                kind: "GetField", 
-                                target: {kind: "GlobalObject", name: TEST_STORE},
-                                field_name: [{kind: "String", value: "l1"}]
+                                kind: "Selection", 
+                                root: {kind: "GlobalObject", name: TEST_STORE},
+                                level: [{kind: "String", value: "l1"}]
                             },
                             key: {kind: "String", value: "global_origin"}
                         }]}
                     },
                     {
                         kind: "Update", 
-                        target: {kind: "Saved", index: 0},
+                        root: {kind: "Saved", index: 0},
                         level: [{kind: "String",value: "clean"}],
                         operation: {kind: "Int", value: 12},
                     },
                     {
                         kind: "Update",
-                        target: {kind: "GlobalObject", name: TEST_STORE},
+                        root: {kind: "GlobalObject", name: TEST_STORE},
                         level: [{kind: "String", value: "l1"}],
                         operation: {kind: "Saved", index: 0}
                     }
@@ -1066,22 +1066,22 @@ describe("global objects", () => {
                         value: {kind: "Object", fields: [{
                             kind: "Field",
                             value: {
-                                kind: "GetField", 
-                                target: {kind: "GlobalObject", name: TEST_STORE},
-                                field_name: [{kind: "String", value: "l1"}]
+                                kind: "Selection", 
+                                root: {kind: "GlobalObject", name: TEST_STORE},
+                                level: [{kind: "String", value: "l1"}]
                             },
                             key: {kind: "String", value: "global_origin"}
                         }]}
                     },
                     {
                         kind: "Update", 
-                        target: {kind: "Saved", index: 0},
+                        root: {kind: "Saved", index: 0},
                         level: [],
                         operation: {kind: "Int", value: 0},
                     },
                     {
                         kind: "Update",
-                        target: {kind: "GlobalObject", name: TEST_STORE},
+                        root: {kind: "GlobalObject", name: TEST_STORE},
                         level: [{kind: "String", value: "l1"}],
                         operation: {kind: "Saved", index: 0}
                 }]

--- a/conder_core/src/main/abstract/abstract.spec.ts
+++ b/conder_core/src/main/abstract/abstract.spec.ts
@@ -458,6 +458,40 @@ describe("basic functionality", () => {
             expect(await server.push(["a"])).toEqual(["a", "hello", 12])
         }
     ))
+    
+    it("allows pushing to nested local arrays", withInputHarness(
+        "no storage",
+        {
+            push: {
+                input: [schemaFactory.Any],
+                computation: [
+                    {
+                        kind: "Update",
+                        root: {kind: "Saved", index: 0},
+                        level: [{kind: "String", value: "array"}],
+                        operation: {
+                            kind: "Push", 
+                            values: [
+                                {kind: "String", value: "hello"},
+                                {kind: "Int", value: 12}
+                            ]
+                        }
+                    },
+                    {
+                        kind: "Return", 
+                        value: {
+                            kind: 'Selection',
+                            root: {kind: "Saved", index: 0},
+                            level: [{kind: "String", value: "array"}]
+                        }
+                    }
+                ],
+            }
+        },
+        async server => {
+            expect(await server.push({array: ["a"]})).toEqual(["a", "hello", 12])
+        }
+    ))
 
     it("allows indexing into arrays with an int", withInputHarness(
         "requires storage",

--- a/conder_core/src/main/abstract/abstract.spec.ts
+++ b/conder_core/src/main/abstract/abstract.spec.ts
@@ -438,6 +438,31 @@ describe("basic functionality", () => {
     })
     )
 
+    it("allows pushing to local arrays", withInputHarness(
+        "no storage",
+        {
+            push: {
+                input: [schemaFactory.Array(schemaFactory.Any)],
+                computation: [
+                    {
+                        kind: "Update",
+                        target: {kind: "Saved", index: 0},
+                        operation: {
+                            kind: "Push", 
+                            values: [
+                                {kind: "String", value: "hello"},
+                                {kind: "Int", value: 12}
+                            ]
+                        }
+                    },
+                    {kind: "Return", value: {kind: "Saved", index: 0}}
+                ],
+            }
+        },
+        async server => {
+            expect(await server.push(["a"])).toEqual(["a", "hello", 12])
+        }
+    ))
 })
 
 describe("with input", () => {

--- a/conder_core/src/main/abstract/compilers.ts
+++ b/conder_core/src/main/abstract/compilers.ts
@@ -224,9 +224,8 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
         case "Selection":
             if (n.level.length > 0) {
                 return [
-                    ...full_compiler(n.root),
                     ...n.level.flatMap(full_compiler),
-                    ow.getField({field_depth: n.level.length})
+                    ow.getSavedField({field_depth: n.level.length, index: n.root.index})
                 ]
             } else {
                 return full_compiler(n.root)

--- a/conder_core/src/main/abstract/compilers.ts
+++ b/conder_core/src/main/abstract/compilers.ts
@@ -180,7 +180,7 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
         
         case "Field":
             return [
-                ...full_compiler(n.key),
+                ...full_compiler(n.key),                
                 ...full_compiler(n.value),
                 ow.setField({field_depth: 1})
             ]
@@ -198,7 +198,6 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
 
                 case "DeleteField":
                     
-                    // n.target.
                     return [
                         ...full_compiler(n.root), 
                         ...n.level.flatMap(full_compiler),
@@ -214,11 +213,9 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
                         ]
                     }
                     return [
-                        ...full_compiler(n.root),
                         ...n.level.flatMap(full_compiler),
-                        ...full_compiler(n.operation),
-                        ow.setField({field_depth: n.level.length}),
-                        ow.overwriteHeap(n.root.index)
+                        ...full_compiler(n.operation),                        
+                        ow.setSavedField({field_depth: n.level.length, index: n.root.index}),
                     ]
             }
         case "Selection":

--- a/conder_core/src/main/abstract/compilers.ts
+++ b/conder_core/src/main/abstract/compilers.ts
@@ -189,12 +189,22 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
             
             switch (n.operation.kind) {
                 case "Push": 
-                    return n.operation.values.flatMap(v => {
+                    if (n.level.length > 0) {
                         return [
-                            ...full_compiler(v),
-                            ow.moveStackToHeapArray(n.root.index)
+                            ...n.level.flatMap(full_compiler),
+                            ow.instantiate([]),
+                            ...n.operation.values.flatMap(v => [...full_compiler(v), ow.arrayPush]),
+                            ow.pushSavedField({field_depth: n.level.length, index: n.root.index})
                         ]
-                    })
+
+                    } else {
+                        return n.operation.values.flatMap(v => {
+                            return [
+                                ...full_compiler(v),
+                                ow.moveStackToHeapArray(n.root.index)
+                            ]
+                        })
+                    }
 
                 case "DeleteField":
                     

--- a/conder_core/src/main/abstract/compilers.ts
+++ b/conder_core/src/main/abstract/compilers.ts
@@ -199,10 +199,8 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
                 case "DeleteField":
                     
                     return [
-                        ...full_compiler(n.root), 
                         ...n.level.flatMap(full_compiler),
-                        ow.deleteField({field_depth: n.level.length}),
-                        ow.overwriteHeap(n.root.index)
+                        ow.deleteSavedField({field_depth: n.level.length, index: n.root.index}),
                     ]
                     
                 default:

--- a/conder_core/src/main/abstract/compilers.ts
+++ b/conder_core/src/main/abstract/compilers.ts
@@ -188,6 +188,14 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
         case "Update":
             
             switch (n.operation.kind) {
+                case "Push": 
+                    return n.operation.values.flatMap(v => {
+                        return [
+                            ...full_compiler(v),
+                            ow.moveStackToHeapArray(n.target.index)
+                        ]
+                    })
+
                 case "SetField":
                 case "DeleteField":
 
@@ -307,10 +315,11 @@ export function base_compiler(n: BaseNodesFromTargetSet<{}>, full_compiler: (a: 
             })
             return arr
 
+        case "Push":
         case "Conditional":
         case "Finally":
         case "Else":
-            throw Error(`${n.kind} should be compiled within if`)
+            throw Error(`${n.kind} should be compiled within parent`)
         default: Utils.assertNever(n)
     }
 }

--- a/conder_core/src/main/abstract/globals/global_replacement.spec.ts
+++ b/conder_core/src/main/abstract/globals/global_replacement.spec.ts
@@ -19,9 +19,9 @@ describe("mongo", () => {
         }
     }
     it("get field with mongo specific op", replaceTest({
-            kind: "GetField",
-            target: {kind: "GlobalObject", name: "global"},
-            field_name: [{kind: "String", value: "field"}]
+            kind: "Selection",
+            root: {kind: "GlobalObject", name: "global"},
+            level: [{kind: "String", value: "field"}]
         })
     )
 
@@ -34,7 +34,7 @@ describe("mongo", () => {
 
     it("can replace SetField updates", replaceTest({
         kind: "Update",
-        target: {kind: "GlobalObject", name: "gg"},
+        root: {kind: "GlobalObject", name: "gg"},
         level: [{kind: "Saved", index: 12}],
         operation: {kind: "String", value: 'some val'}
     }))

--- a/conder_core/src/main/abstract/globals/global_replacement.spec.ts
+++ b/conder_core/src/main/abstract/globals/global_replacement.spec.ts
@@ -35,6 +35,7 @@ describe("mongo", () => {
     it("can replace SetField updates", replaceTest({
         kind: "Update",
         target: {kind: "GlobalObject", name: "gg"},
-        operation: {kind: "SetField", value: {kind: "String", value: 'some val'}, field_name: [{kind: "Saved", index: 12}]}
+        level: [{kind: "Saved", index: 12}],
+        operation: {kind: "String", value: 'some val'}
     }))
 })

--- a/conder_core/src/main/abstract/globals/mongo.ts
+++ b/conder_core/src/main/abstract/globals/mongo.ts
@@ -25,6 +25,18 @@ const MONGO_REPLACER: RequiredReplacer<MongoNodeSet> = {
     Finally(n, r) {
         return {kind: "Finally", do: n.do.map(r)}
     },
+
+    Push(n, r) {
+        return {
+            kind: "Push", values: n.values.map(v => {
+                if (v.kind === "GlobalObject") {
+                    throw Error(`Cannot use global object in a push`)
+                }
+                return r(v)
+            })
+        }
+    },
+
     ArrayLiteral(n, r) {
         return {
             kind: "ArrayLiteral",

--- a/conder_core/src/main/abstract/mongo_logic/action_summarizer.ts
+++ b/conder_core/src/main/abstract/mongo_logic/action_summarizer.ts
@@ -158,7 +158,7 @@ const SUMMARIZER_SUBSCRIPTIONS: Subscriptions<IntuitiveSummarizerState, keyof Mo
     Update: {
         before: (n, state, this_visitor) => {
             state.startSummaryGroup() 
-            switch (n.target.kind) {
+            switch (n.root.kind) {
                 case "Saved":
                     break
 
@@ -170,10 +170,10 @@ const SUMMARIZER_SUBSCRIPTIONS: Subscriptions<IntuitiveSummarizerState, keyof Mo
             this_visitor.apply([n.operation])
             const summary = state.endSummaryGroup()
             const is_partial_update = "Push" === n.operation.kind || n.level.length > 0
-            const taint = is_partial_update ? state.taints.get(n.target.index) : new Set<string>()
+            const taint = is_partial_update ? state.taints.get(n.root.index) : new Set<string>()
             summary.uses_data_with_taints.forEach(t => taint.add(t))
             summary.may_perform.forEach(c => taint.add(c.id))
-            state.taints.set(n.target.index, taint)
+            state.taints.set(n.root.index, taint)
         },
         after: (n, state) => {
             

--- a/conder_core/src/main/abstract/mongo_logic/action_summarizer.ts
+++ b/conder_core/src/main/abstract/mongo_logic/action_summarizer.ts
@@ -169,7 +169,7 @@ const SUMMARIZER_SUBSCRIPTIONS: Subscriptions<IntuitiveSummarizerState, keyof Mo
             
             this_visitor.apply([n.operation])
             const summary = state.endSummaryGroup()
-            const taint = n.operation.kind === "SetField" ? state.taints.get(n.target.index) : new Set<string>()
+            const taint = ["SetField", "Push"].includes(n.operation.kind) ? state.taints.get(n.target.index) : new Set<string>()
             summary.uses_data_with_taints.forEach(t => taint.add(t))
             summary.may_perform.forEach(c => taint.add(c.id))
             state.taints.set(n.target.index, taint)

--- a/conder_core/src/main/abstract/mongo_logic/action_summarizer.ts
+++ b/conder_core/src/main/abstract/mongo_logic/action_summarizer.ts
@@ -169,7 +169,8 @@ const SUMMARIZER_SUBSCRIPTIONS: Subscriptions<IntuitiveSummarizerState, keyof Mo
             
             this_visitor.apply([n.operation])
             const summary = state.endSummaryGroup()
-            const taint = ["SetField", "Push"].includes(n.operation.kind) ? state.taints.get(n.target.index) : new Set<string>()
+            const is_partial_update = "Push" === n.operation.kind || n.level.length > 0
+            const taint = is_partial_update ? state.taints.get(n.target.index) : new Set<string>()
             summary.uses_data_with_taints.forEach(t => taint.add(t))
             summary.may_perform.forEach(c => taint.add(c.id))
             state.taints.set(n.target.index, taint)

--- a/conder_core/src/main/data_structures/visitor.spec.ts
+++ b/conder_core/src/main/data_structures/visitor.spec.ts
@@ -56,10 +56,10 @@ describe("visitor traversal order", () => {
         "Before SetKeyOnObject ",
         "Before String target_key",
         "After String target_key",
-        "Before GetField ",
+        "Before Selection ",
         "Before String get_key",
         "After String get_key",
-        "After GetField ",
+        "After Selection ",
         "After SetKeyOnObject ",
       ]
     `);

--- a/conder_core/src/main/data_structures/visitor.spec.ts
+++ b/conder_core/src/main/data_structures/visitor.spec.ts
@@ -20,7 +20,7 @@ describe("visitor traversal order", () => {
       {
         Math: { before, after },
         Int: { before, after },
-        GetField: { before, after },
+        Selection: { before, after },
         String: { before, after },
         SetKeyOnObject: { before, after },
       },
@@ -38,9 +38,9 @@ describe("visitor traversal order", () => {
         kind: "SetKeyOnObject",
         obj: "global_object",
         value: {
-          kind: "GetField",
-          target: { kind: "Saved", index: 0 },
-          field_name: [{ kind: "String", value: "get_key" }],
+          kind: "Selection",
+          root: { kind: "Saved", index: 0 },
+          level: [{ kind: "String", value: "get_key" }],
         },
         key: [{ kind: "String", value: "target_key" }],
       },

--- a/conder_core/src/main/data_structures/visitor.ts
+++ b/conder_core/src/main/data_structures/visitor.ts
@@ -73,8 +73,8 @@ function extract_children(n: TargetNodes): TargetNodes[] {
         case "DeleteKeyOnObject":
             return n.key
 
-        case "GetField":
-            return [n.target, ...n.field_name]
+        case "Selection":
+            return [n.root, ...n.level]
 
         case "FieldExists":
             return [n.value, n.field]
@@ -82,7 +82,7 @@ function extract_children(n: TargetNodes): TargetNodes[] {
         case "keyExists":
             return [n.key]
         case "Update":
-            return [n.target, n.operation]
+            return [n.root, n.operation]
         case "SetKeyOnObject":
             return [...n.key, n.value]
         case "Field":                

--- a/conder_core/src/main/data_structures/visitor.ts
+++ b/conder_core/src/main/data_structures/visitor.ts
@@ -103,6 +103,7 @@ function extract_children(n: TargetNodes): TargetNodes[] {
             return [n.target, ...n.do]
 
         case "ArrayLiteral":
+        case "Push":
             return n.values
         case "Else":
         case "Finally":

--- a/conder_core/src/main/data_structures/visitor.ts
+++ b/conder_core/src/main/data_structures/visitor.ts
@@ -78,9 +78,6 @@ function extract_children(n: TargetNodes): TargetNodes[] {
 
         case "FieldExists":
             return [n.value, n.field]
-
-        case "DeleteField":
-            return n.field_name
         
         case "keyExists":
             return [n.key]
@@ -88,8 +85,8 @@ function extract_children(n: TargetNodes): TargetNodes[] {
             return [n.target, n.operation]
         case "SetKeyOnObject":
             return [...n.key, n.value]
-        case "SetField":                
-            return [...n.field_name, n.value]
+        case "Field":                
+            return [n.key, n.value]
 
         case "Int":                
         case "GetWholeObject":
@@ -98,6 +95,7 @@ function extract_children(n: TargetNodes): TargetNodes[] {
         case "Saved":
         case "None":
         case "Noop":
+        case "DeleteField":
             return []
         case "ArrayForEach":
             return [n.target, ...n.do]

--- a/conder_core/src/main/ops/interpreter/supported_op_definition.ts
+++ b/conder_core/src/main/ops/interpreter/supported_op_definition.ts
@@ -76,7 +76,7 @@ StaticOp<"nDivide"> |
 StaticOp<"nMult"> 
 
 
-function getField(data: {depth: string, location: {save: string} | "stack"}): string {
+function againstField(data: {depth: string, location: {save: string} | "stack"}): string {
     return `
             let mut fields = Vec::with_capacity(${data.depth});
             for n in 1..=${data.depth} {
@@ -339,14 +339,14 @@ export const OpSpec: CompleteOpSpec = {
     getField: {
         opDefinition: {
             paramType: ["usize"],
-            rustOpHandler: getField({depth: "*op_param", location: "stack"})
+            rustOpHandler: againstField({depth: "*op_param", location: "stack"})
         },
         factoryMethod: ({field_depth}) => ({kind: "getField", data: field_depth})
     },
     getSavedField: {
         opDefinition: {
             paramType: ["usize", "usize"],
-            rustOpHandler: getField({depth: "*param0", location: {save: "*param1"}})
+            rustOpHandler: againstField({depth: "*param0", location: {save: "*param1"}})
         },
         factoryMethod: ({field_depth, index}) => ({kind: "getSavedField", data: [field_depth, index]})
     },

--- a/conder_core/src/main/ops/ops.spec.ts
+++ b/conder_core/src/main/ops/ops.spec.ts
@@ -118,11 +118,11 @@ describe("conduit kernel", () => {
       {
         PROCEDURES: {
           delete: [
-            ow.copyFromHeap(0),
+            
             ow.instantiate("l1"),
             ow.instantiate("l2"),
-            ow.deleteField({ field_depth: 2 }),
-            ow.returnStackTop,
+            ow.deleteSavedField({ field_depth: 2, index: 0}),
+            ow.returnVariable(0),
           ],
         },
       }


### PR DESCRIPTION
Closes #43
- Push on local arrays
- Update node contains level info
- Updates may be applied to any selection
- Can index into global objects with an int
- May index into local arrays
- extract getField generate out to be parameterized
- getField can target a saved variable
- Rename to againstField
- Update snapshot
- Parameterize action against field
- Setfield uses the shared harness
- Delete field follows same pattern as other mutations
- May push at any level of nesting
